### PR TITLE
Spelling/grammar/accuracy fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 We are putting together a collection of community resources for a new section on the Pebble Developer Website, and we need *your* contributions!
 
-There are three types of content we are looking for, **[Example Apps](#example-apps)**, **[Developer Tools](#developer-tools)**, and **[Libraries](#libraries)**.
+There are three types of content we are looking for: **[Example Apps](#example-apps)**, **[Developer Tools](#developer-tools)**, and **[Libraries](#libraries)**.
 
-To add your app, tool, or library to the collection, simply [fork this GitHub repository][1], follow the relevant guide below to create a Markdown file in the right folder, and submit a pull request. 
+To add your resource to the collection, simply [fork this GitHub repository][fork], follow the relevant guide below to create a Markdown file in the right folder, and submit a pull request. 
 
-You can also take a look at some of the apps, tools, and libraries that have already been submitted to see how to do it.
+You can also take a look at some of the resources that have already been submitted to see how to do it.
 
 ### Example Apps
 
-We are looking for well written apps that other people can use to learn Pebble development.
+We are looking for well-written apps that other people can use to learn Pebble development.
 
-**NOTE:** You must provide a license for your apps in order for it to get approved. The best way to do that is to include a LICENSE file in your app repository.
+**NOTE:** You must provide an open-source license for your apps in order for it to be approved. The best way to do that is to include a LICENSE file in your app repository.
 
 To add your app, create a new Markdown file in the `apps` folder with the same name as your app (in a URL friendly style, such as `multi-timer.md` or `uk-transport.md`)
 
-At the top of your Markdown file, you will need to have a metadata block that contains the folllowing properties.
+At the top of your Markdown file you will need to have a metadata block that contains the following properties:
 
 ```
 ---
@@ -31,7 +31,7 @@ tags:
 ---
 ```
 
-Hopefully `name`, `creator` and `link` are self explanatory. The `appstore` entry is be the Pebble Appstore ID for your app. If your app isn't on the Pebble appstore, omit this line. The `tags`  property will be used on the site to let people browse by different properties. See below for the list of all of the possible tags.
+Hopefully `name`, `creator` and `url` are self-explanatory. The `appstore` entry is the Pebble appstore ID for your app. If your app isn't on the Pebble appstore, omit this line. The `tags`  list will be used on the site to let people browse by different tags. See below for the list of all of the possible tags.
 
 Below this metadata block you should write a description of your app. Include details of the key features it has.
 
@@ -48,9 +48,9 @@ Below this metadata block you should write a description of your app. Include de
 
 ### Developer Tools
 
-To add your tool, create a new Markdown file in the `tools` folder with the same name as your tool (in a URL friendly style, such as `watchface-generator.md` or `pebble-local-simulator.md`)
+To add your tool, create a new Markdown file in the `tools` folder with the same name as your tool (in a URL-friendly style, such as `watchface-generator.md` or `pebble-local-simulator.md`)
 
-At the top of your Markdown file, you will need to have a metadata block that contains the folllowing properties.
+At the top of your Markdown file, you will need to have a metadata block that contains the following properties.
 
 ```
 ---
@@ -64,11 +64,11 @@ Below this metadata block you should write a description of your tool.
 
 ### Libraries
 
-**NOTE:** You must provide a license for your library in order for it to get approved. The best way to do that is to include a LICENSE file in the repository for your library.
+**NOTE:** You must provide an open-source license for your library in order for it to be approved. The best way to do that is to include a LICENSE file in the repository for your library.
 
-To add your library, create a new Markdown file in the `libraries` folder with the same name as your tool (in a URL friendly style, such as `js-message-queue.md` or `clock-layer.md`).
+To add your library create a new Markdown file in the `libraries` folder with the same name as your library (in a URL-friendly style, such as `js-message-queue.md` or `clock-layer.md`).
 
-At the top of your Markdown file, you will need to have a metadata block that contains the folllowing properties.
+At the top of your Markdown file you will need to have a metadata block that contains the following properties.
 
 
 ```
@@ -80,8 +80,8 @@ language: js
 ---
 ```
 
-The `language` property should be one of `c`, `js`, `android` or `ios`. This will help people find your library.
+The `language` property should be one of `c`, `js`, `android`, or `ios`. This will help people find your library.
 
-Below the metadata block you should write a description of your library. Talk about what problem it aims to solve, and how people should use it.
+Below the metadata block you should write a description of your library. Talk about what problem it aims to solve and how people should use it.
 
-[1]: https://github.com/pebble-hacks/community-resources/fork
+[fork]: https://github.com/pebble-hacks/community-resources/fork


### PR DESCRIPTION
Nitpicking!
- `url` should not sometimes be `link`
- "apps, tools, and libraries" gets really repetitive
- Reduce extraneous commas
- Be consistent about use of the oxford comma
- open source!
