### PR TITLE
Added markdown for T3 Keyboard

### DIFF
--- a/libraries/t3-keyboard.md
+++ b/libraries/t3-keyboard.md
@@ -1,0 +1,23 @@
+---
+name: T3 Keyboard
+creator: Chris Nucci
+link: https://github.com/cnucci/t3-keyboard
+language: c
+---
+
+Advantages
+==========
+
+The T3 Keyboard provides a fast and intuitive method for textual input on the Pebble smartwatch.
+
+Usage
+=====
+
+1. Add T3Window.h and T3Window.c to your Pebble project.
+2. Include T3Window.h on the file that uses the T3 Keyboard.
+3. Define keyboard sets and layouts or use pre-defined ones.
+4. Define a handler to get the inputted text.
+5. Create the window and show it.
+6. Profit!
+
+Get more details at the repo listed above.


### PR DESCRIPTION
This is a new markdown for the T3 Keyboard library. Additional information is available at the associated repo.
